### PR TITLE
[FEAT] Improve the pin-bot workflow 📌

### DIFF
--- a/app/bot.py
+++ b/app/bot.py
@@ -11,6 +11,25 @@ def main():
     sys.stdout.flush()
     bot.run(os.getenv("TOKEN"))
 
+
+@bot.event
+async def on_raw_reaction_add(payload):
+    channel = await bot.fetch_channel(payload.channel_id)
+    message = await channel.fetch_message(payload.message_id)
+
+    if not message.pinned and payload.emoji.name == '📌':
+        await message.pin()
+
+
+@bot.event
+async def on_raw_reaction_remove(payload):
+    channel = await bot.fetch_channel(payload.channel_id)
+    message = await channel.fetch_message(payload.message_id)
+
+    if payload.emoji.name == '📌' and message.pinned:
+        await message.unpin()
+
+
 @bot.event
 async def on_ready():
     print("Ready!")

--- a/app/bot.py
+++ b/app/bot.py
@@ -71,6 +71,11 @@ async def on_raw_reaction_add(payload):
     channel = await bot.fetch_channel(payload.channel_id)
     message = await channel.fetch_message(payload.message_id)
 
+    if message.is_system():
+        await channel.send("Cannot pin system messages!")
+        await message.clear_reaction(reaction_emoji)
+        return
+
     existing_reactions = get_reactions_from_message(message)
 
     if payload.emoji.name == reaction_emoji:

--- a/app/bot.py
+++ b/app/bot.py
@@ -26,7 +26,7 @@ async def pin(ctx):
             await ctx.send("Message is already pinned")
         else:
             await message.pin()
-    except:
+    except Exception:
         await ctx.send("Something went wrong. Make sure your URL is correct and valid.")
 
 @bot.command(description="Unpin a message. Argument: URL of message to be unpinned")
@@ -52,7 +52,7 @@ async def get_message(ctx):
                 return await ctx.message.channel.fetch_message(ids[-1])
             else:
                 return None
-        except:
+        except Exception:
             return None
     else:
         return None        

--- a/app/bot.py
+++ b/app/bot.py
@@ -4,13 +4,28 @@ import discord
 from discord.ext import commands
 from dotenv import load_dotenv
 
-bot = commands.Bot(command_prefix='/')
+
+reaction_emoji = '📌'
+
+prefix_map = {
+    reaction_emoji: ''
+}
 
 
-def main():
-    load_dotenv()
-    sys.stdout.flush()
-    bot.run(os.getenv("TOKEN"))
+def select_command_prefix(_bot, message):
+    return prefix_map.get(message.clean_content[0], '/')
+
+
+bot = commands.Bot(command_prefix=select_command_prefix,
+                   description=f"You can now react to messages with {reaction_emoji} to pin a message!")
+
+
+@bot.event
+async def on_ready():
+    print("Ready!")
+    activity = discord.Activity(name="/help pin to get started!",
+                                type=discord.ActivityType.watching)
+    await bot.change_presence(status=discord.Status.online, activity=activity)
 
 
 @bot.event
@@ -18,8 +33,16 @@ async def on_raw_reaction_add(payload):
     channel = await bot.fetch_channel(payload.channel_id)
     message = await channel.fetch_message(payload.message_id)
 
-    if not message.pinned and payload.emoji.name == '📌':
-        await message.pin()
+    if payload.emoji.name == reaction_emoji:
+        if not message.pinned:
+            await message.pin()
+        else:
+            pin_reaction = {
+                r.emoji: r for r in message.reactions
+            }.get(reaction_emoji)
+
+            if pin_reaction and pin_reaction.me:
+                await message.remove_reaction(reaction_emoji, bot.user)
 
 
 @bot.event
@@ -27,44 +50,43 @@ async def on_raw_reaction_remove(payload):
     channel = await bot.fetch_channel(payload.channel_id)
     message = await channel.fetch_message(payload.message_id)
 
-    if payload.emoji.name == '📌' and message.pinned:
+    if payload.emoji.name == reaction_emoji and message.pinned:
         await message.unpin()
+        await message.clear_reaction(reaction_emoji)
+        await channel.send("Unpinned!")
 
 
-@bot.event
-async def on_ready():
-    print("Ready!")
-    activity = discord.Activity(name="/pin {url} to pin a message!",
-                                type=discord.ActivityType.watching)
-    await bot.change_presence(status=discord.Status.online, activity=activity)
-
-
-@bot.command(description="Pin a message. Argument: URL of message to be pinned")
+@bot.command(description="Pin a message. Argument: URL of the  message to be pinned or message itself", aliases=[reaction_emoji])
 async def pin(ctx):
-    message = await get_message(ctx)
     try:
+        message = await get_message_from_url(ctx)
+        if not message:
+            message = ctx.message
+
         if message.pinned == True:
             await ctx.send("Message is already pinned")
         else:
-            await message.pin()
+            # this will trigger on_raw_reaction_add to actually pin the message
+            await message.add_reaction(reaction_emoji)
     except Exception:
         await ctx.send("Something went wrong. Make sure your URL is correct and valid.")
 
 
 @bot.command(description="Unpin a message. Argument: URL of message to be unpinned")
 async def unpin(ctx):
-    message = await get_message(ctx)
+    message = await get_message_from_url(ctx)
+
     try:
         if message.pinned == False:
             await ctx.send("Message is not pinned")
         else:
-            await message.unpin()
-            await ctx.send("Unpinned!")
-    except:
+            # this will trigger on_raw_reaction_remove to actually unpin the message
+            await message.remove_reaction(reaction_emoji, bot.user)
+    except Exception:
         await ctx.send("Something went wrong. Make sure your URL is correct and valid.")
 
 
-async def get_message(ctx):
+async def get_message_from_url(ctx):
     message_url = ctx.message.clean_content.split(' ')[1]
 
     # Check if url is from Discord
@@ -79,6 +101,13 @@ async def get_message(ctx):
             return None
     else:
         return None
+
+
+def main():
+    load_dotenv()
+    sys.stdout.flush()
+    bot.run(os.getenv("TOKEN"))
+
 
 if __name__ == '__main__':
     main()

--- a/app/bot.py
+++ b/app/bot.py
@@ -6,6 +6,7 @@ from dotenv import load_dotenv
 
 bot = commands.Bot(command_prefix='/')
 
+
 def main():
     load_dotenv()
     sys.stdout.flush()
@@ -34,8 +35,9 @@ async def on_raw_reaction_remove(payload):
 async def on_ready():
     print("Ready!")
     activity = discord.Activity(name="/pin {url} to pin a message!",
-                                      type=discord.ActivityType.watching)
+                                type=discord.ActivityType.watching)
     await bot.change_presence(status=discord.Status.online, activity=activity)
+
 
 @bot.command(description="Pin a message. Argument: URL of message to be pinned")
 async def pin(ctx):
@@ -47,6 +49,7 @@ async def pin(ctx):
             await message.pin()
     except Exception:
         await ctx.send("Something went wrong. Make sure your URL is correct and valid.")
+
 
 @bot.command(description="Unpin a message. Argument: URL of message to be unpinned")
 async def unpin(ctx):
@@ -60,6 +63,7 @@ async def unpin(ctx):
     except:
         await ctx.send("Something went wrong. Make sure your URL is correct and valid.")
 
+
 async def get_message(ctx):
     message_url = ctx.message.clean_content.split(' ')[1]
 
@@ -67,14 +71,14 @@ async def get_message(ctx):
     if message_url[:23] == "https://discordapp.com/" or message_url[:20] == "https://discord.com/":
         try:
             ids = message_url.split('/')
-            if len(ids)  == 7: 
+            if len(ids) == 7:
                 return await ctx.message.channel.fetch_message(ids[-1])
             else:
                 return None
         except Exception:
             return None
     else:
-        return None        
+        return None
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Listens to reactions to messages on the server, namely the 📌 emoji, and can pin and unpin the message depending on whether the 📌 was added or removed.

Added inline `/pin` and support for 📌 as a prefix. E.G.

```
/pin this message
📌 pin this one too
```